### PR TITLE
Remove extra bracket in saga-nyc theme

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,10 +34,10 @@
     <meta property="og:title" content="{{current.fields.SEO.title}}" />
     <meta name="twitter:title" content="{{current.fields.SEO.title}}">
   {% elif current.meta_title %}
-    <meta property="og:title" content="{{current.meta_title}}}" />
+    <meta property="og:title" content="{{current.meta_title}}" />
     <meta name="twitter:title" content="{{current.meta_title}}">
   {% else %}
-    <meta property="og:title" content="{{current.name}} - {{ account.site.title }}}" />
+    <meta property="og:title" content="{{current.name}} - {{ account.site.title }}" />
     <meta name="twitter:title" content="{{current.name}} - {{ account.site.title }}">
   {% endif %}
 


### PR DESCRIPTION
Changes the og:title property from "Home - SAGA}" to "Home - SAGA". 

https://getbentobox.atlassian.net/browse/PSE-3962